### PR TITLE
fix: ensure correct connected network

### DIFF
--- a/src/lib/withdraw/actions/connect-wallet.ts
+++ b/src/lib/withdraw/actions/connect-wallet.ts
@@ -4,7 +4,7 @@ import { iscAbi, iscContractAddress } from '$lib/withdraw';
 import { WTOKEN_CONTRACT_CHAIN_MAP, wIOTAAbi, wSMRAbi, wToken } from '$lib/wrap';
 import { defaultEvmStores, selectedAccount, web3 } from 'svelte-web3';
 import { get } from 'svelte/store';
-import { addSelectedNetworkToMetamask, subscribeBalance } from '.';
+import { addSelectedNetworkToMetamask, subscribeBalance, subscribeConnectedNetwork } from '.';
 import { updateWithdrawStateStore, withdrawStateStore } from '../stores';
 
 export async function connectToWallet() {
@@ -35,6 +35,7 @@ export async function connectToWallet() {
     const wTokenContractObj = new wToken(get(withdrawStateStore)?.contractWToken);
     updateWithdrawStateStore({ wTokenContractObj });
 
+    await subscribeConnectedNetwork();
     await subscribeBalance();
   } catch (ex) {
     console.error('Failed to connect to wallet: ', ex.message);

--- a/src/lib/withdraw/actions/disconnect-wallet.ts
+++ b/src/lib/withdraw/actions/disconnect-wallet.ts
@@ -1,8 +1,9 @@
 import { defaultEvmStores } from 'svelte-web3';
 
-import { unsubscribeBalance } from './subscriptions';
+import { unsubscribeConnectedNetwork, unsubscribeBalance } from './subscriptions';
 
 export async function disconnectWallet(): Promise<void> {
   await defaultEvmStores.disconnect();
+  unsubscribeConnectedNetwork();
   unsubscribeBalance();
 }

--- a/src/lib/withdraw/actions/subscriptions.ts
+++ b/src/lib/withdraw/actions/subscriptions.ts
@@ -39,7 +39,7 @@ let connectedNetworkInterval: NodeJS.Timeout | null = null;
 export async function subscribeConnectedNetwork() {
   connectedNetworkInterval = setInterval(async () => {
     if (get(connected) || get(selectedAccount)) {
-      if (Number(get(chainId))?.toString() !== Number(get(selectedNetwork)?.chainID)?.toString()) {
+      if (BigInt(get(chainId)) !== BigInt(get(selectedNetwork)?.chainID)) {
         try {
           await disconnectWallet();
         } catch (e) {
@@ -58,8 +58,4 @@ export async function unsubscribeConnectedNetwork() {
   if (connectedNetworkInterval) {
     clearInterval(connectedNetworkInterval);
   }
-}
-
-function big(arg0: number): any {
-  throw new Error('Function not implemented.');
 }


### PR DESCRIPTION
# Description of change

The current toolkit does not check that the network you are connected to is the same that you connected originally, the user might have changed it, leading to actions and balances pointing to the network connected in metamask, but not the selected configured network in the toolkit

This PR aims to fix that by adding a 1s poll to ensure the user is always connected to the right network, if not, the toolkit disconnects

## Links to any relevant issues

<!-- Be sure to reference any related issues by adding `fixes #issue_number`. -->

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
